### PR TITLE
use clux/muslrust:latest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM clux/muslrust:1.41.1-stable
+FROM clux/muslrust
 
 COPY entrypoint.sh /entrypoint.sh
 


### PR DESCRIPTION
Hi this is so helpful when building a binary for lambda running. Thanks!
Could we use latest tag of clux/muslrust image in Docker file?
I think this would enable more people's code to be built